### PR TITLE
chore: use order only prerequisites for targets depending on bin directory

### DIFF
--- a/go.mk
+++ b/go.mk
@@ -13,11 +13,11 @@ GOLANGCILINT := bin/golangci-lint
 GOLANGCILINT_VERSION ?= v1.42.0
 GOLANGCILINT_CONCURRENCY ?= 16
 
-$(GOFUMPT): $(BIN)
+$(GOFUMPT): | $(BIN)
 	$(info $(_bullet) Installing <gofumpt>)
 	GOBIN=$(BIN) $(GO) install mvdan.cc/gofumpt@$(GOFUMPT_VERSION)
 
-$(GOLANGCILINT): $(BIN)
+$(GOLANGCILINT): | $(BIN)
 	$(info $(_bullet) Installing <golangci-lint>)
 	GOBIN=$(BIN) $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCILINT_VERSION)
 

--- a/kind.mk
+++ b/kind.mk
@@ -13,7 +13,7 @@ KIND_HOST_PORT ?= 80
 
 BOOTSTRAP_CONTEXT := kind-$(KIND_CLUSTER_NAME)
 
-$(KIND): $(BIN)
+$(KIND): | $(BIN)
 	$(info $(_bullet) Installing <kind>)
 	curl -sSfL https://kind.sigs.k8s.io/dl/$(KIND_VERSION)/kind-$(OS)-$(ARCH) -o $(KIND)
 	chmod u+x $(KIND)

--- a/kubectl.mk
+++ b/kubectl.mk
@@ -6,7 +6,7 @@ include makefiles/shared.mk
 KUBECTL := $(BIN)/kubectl
 KUBECTL_VERSION ?= v1.21.4
 
-$(KUBECTL): $(BIN)
+$(KUBECTL): | $(BIN)
 	$(info $(_bullet) Installing <kubectl>)
 	curl -sSfL https://storage.googleapis.com/kubernetes-release/release/$(KUBECTL_VERSION)/bin/$(OS)/amd64/kubectl -o $(KUBECTL)
 	chmod u+x $(KUBECTL)

--- a/skaffold.mk
+++ b/skaffold.mk
@@ -7,7 +7,7 @@ include makefiles/kubectl.mk
 SKAFFOLD := $(BIN)/skaffold
 SKAFFOLD_VERSION ?= 1.30.0
 
-$(SKAFFOLD): $(BIN)
+$(SKAFFOLD): | $(BIN)
 	$(info $(_bullet) Installing <skaffold>)
 	curl -sSfL https://storage.googleapis.com/skaffold/releases/v$(SKAFFOLD_VERSION)/skaffold-$(OS)-$(ARCH) -o $(SKAFFOLD)
 	chmod u+x $(SKAFFOLD)

--- a/sqlc.mk
+++ b/sqlc.mk
@@ -6,7 +6,7 @@ include makefiles/go.mk
 SQLC := $(abspath bin/sqlc)
 SQLC_VERSION ?= v1.7.0
 
-$(SQLC): $(BIN)
+$(SQLC): | $(BIN)
 	$(info $(_bullet) Installing <sqlc>)
 	GOBIN=$(BIN) go install github.com/kyleconroy/sqlc/cmd/sqlc@$(SQLC_VERSION)
 


### PR DESCRIPTION
I noticed that the binaries that I already installed were intermittently being re-installed. I think the issue is the `bin` directory metadata is changing and causing the dependent targets to rebuild.

I found this guide on [order only prerequisites](http://www.gnu.org/savannah-checkouts/gnu/make/manual/html_node/Prerequisite-Types.html#Prerequisite-Types). After using the order only prerequisite it seemed to solve the issue for me.